### PR TITLE
Fix type picker not returning to observation review after selection.

### DIFF
--- a/lib/src/screens/observation_review_screen.dart
+++ b/lib/src/screens/observation_review_screen.dart
@@ -352,8 +352,9 @@ class _ObservationReviewScreenState extends ConsumerState<ObservationReviewScree
       AppRoutes.types(
         onPick: (type) {
           setState(() => _selectedType = type);
-          Navigator.of(context).popUntil((route) => route.settings.name == 'type_picker');
-          Navigator.of(context).pop();
+          Navigator.of(context).popUntil(
+            (route) => route.settings.name == 'observation_review',
+          );
         },
       ),
     );


### PR DESCRIPTION
Pop until the review screen is reached so nested type_picker routes are fully dismissed.